### PR TITLE
Add customizable keyboard controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -514,7 +514,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.0.0.tgz",
       "integrity": "sha512-250HTVd/W/KdMygoqaedisvNbHbpbQTN2Hy/8ZYGm1nAqE0Fx7sGss4l0nDg33STxEdDhtVRoL2fIaaiukKseA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1917,7 +1916,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2569,7 +2567,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4579,7 +4576,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5587,7 +5583,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5716,7 +5711,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7467,7 +7461,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7542,7 +7535,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
       "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import Library from "../views/Library.vue";
 import Player from "../views/Player.vue";
 import Settings from "../views/Settings.vue";
 import SavesManager from "../views/SavesManager.vue";
+import Input from "../views/Input.vue";
 
 const router = createRouter({
   history: createWebHashHistory(import.meta.env.BASE_URL),
@@ -28,6 +29,11 @@ const router = createRouter({
       path: "/settings/saves",
       name: "saves",
       component: SavesManager,
+    },
+    {
+      path: "/settings/input",
+      name: "input",
+      component: Input,
     },
   ],
 });

--- a/src/services/InputManager.js
+++ b/src/services/InputManager.js
@@ -401,8 +401,7 @@ class InputManagerService {
       this.emitChange("menu", buf.select);
 
       if (window.pico8_gpio) {
-        const picoMenuRequested =
-          buf.start || this.keys["Enter"] || this.keys["p"] || this.keys["P"];
+        const picoMenuRequested = (this._currentState & PicoButton.PAUSE) !== 0 || buf.start;
         window.pico8_gpio[0] = picoMenuRequested ? 1 : 0;
       }
     }
@@ -410,13 +409,14 @@ class InputManagerService {
     else {
       // nav
       const isTyping = document.activeElement?.tagName === "INPUT";
+      const mask = this._keyMask | this._virtualMask;
 
-      this.handleNavInput("nav-up", buf.up);
-      this.handleNavInput("nav-down", buf.down);
+      this.handleNavInput("nav-up", (mask & PicoButton.UP) !== 0);
+      this.handleNavInput("nav-down", (mask & PicoButton.DOWN) !== 0);
 
       if (!isTyping) {
-        this.handleNavInput("nav-left", buf.left);
-        this.handleNavInput("nav-right", buf.right);
+        this.handleNavInput("nav-left",(mask & PicoButton.LEFT) !== 0);
+        this.handleNavInput("nav-right", (mask & PicoButton.RIGHT) !== 0);
       }
 
       // confirm / back
@@ -434,13 +434,12 @@ class InputManagerService {
 
       // keyboard
       if (
-        this.keys["z"] ||
-        this.keys["Z"] ||
+        (mask & PicoButton.O) !== 0 ||
         this.keys["Enter"] ||
         this.keys[" "]
       )
         confirm = true;
-      if (this.keys["x"] || this.keys["X"] || this.keys["Escape"]) back = true;
+      if ((mask & PicoButton.X !== 0) || this.keys["Escape"]) back = true;
 
       this.emitChange("confirm", confirm);
       this.emitChange("back", back);

--- a/src/stores/library.js
+++ b/src/stores/library.js
@@ -21,10 +21,8 @@ export const useLibraryStore = defineStore("library", () => {
     localStorage.getItem("pico_haptics_enabled") !== "false"
   ); // default true
   const rootDir = ref(localStorage.getItem("pico_root_dir") || "");
-  const keymap = ref({
-    ...DEFAULT_KEYMAP,
-    ...loadKeymap(),
-  });
+  const savedKeymap = loadKeymap();
+  const keymap = ref(savedKeymap ?? DEFAULT_KEYMAP);
 
   function loadKeymap() {
     try {

--- a/src/views/Input.vue
+++ b/src/views/Input.vue
@@ -1,0 +1,262 @@
+<template>
+  <div
+    class="min-h-screen w-full bg-oled-dark text-white p-6 pt-16 overflow-y-auto no-scrollbar"
+  >
+    <!-- header -->
+    <div class="flex items-center gap-4 mb-8">
+      <button
+        @click="$router.back()"
+        class="w-10 h-10 rounded-full bg-white/10 flex items-center justify-center active:bg-white/20 transition-all"
+        :class="{ 'ring-2 ring-purple-500 bg-white/20': headerFocused }"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-6 w-6 text-white/80"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15 19l-7-7 7-7"
+          />
+        </svg>
+      </button>
+      <h1
+        class="font-pico-crisp text-white drop-shadow-md text-[clamp(1.5rem,5vw,3rem)]"
+      >
+        Input
+      </h1>
+    </div>
+
+    <!-- Dialog -->
+    <div
+      v-if="showDialog"
+      class="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+    >
+      <div class="bg-oled-dark p-6 rounded-xl w-80 border border-white/10">
+        <h2 class="text-sm font-bold mb-3">Key already bound</h2>
+
+        <p class="text-xs text-white/60 mb-6 whitespace-pre-line">
+          {{ dialogMessage }}
+        </p>
+
+        <div class="flex gap-2 justify-end">
+          <button
+            @click="showDialog = false"
+            class="px-3 py-1 bg-white/10 rounded"
+          >
+            Cancel
+          </button>
+
+          <button
+            @click="replaceBinding"
+            class="px-3 py-1 bg-red-500/20 text-red-400 rounded"
+          >
+            Replace
+          </button>
+
+          <button
+            @click="addBinding"
+            class="px-3 py-1 bg-purple-500 text-white rounded"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Listening overlay -->
+    <div
+      v-if="isListening()"
+      class="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+    >
+      <div
+        class="bg-white/10 border border-white/20 rounded-xl p-6 text-center"
+      >
+        <p class="text-lg font-medium mb-2">Press a key…</p>
+        <p class="text-xs text-white/50">
+          (Timeout {{ listenRemaining }} seconds)
+        </p>
+      </div>
+    </div>
+
+    <!-- Actions -->
+    <div class="space-y-4 max-w-xl mx-auto">
+      <div
+        v-for="action in actions"
+        :key="action.bit"
+        class="p-4 bg-white/5 rounded-xl border border-white/10"
+      >
+        <div class="flex items-center justify-between mb-3">
+          <span class="font-medium">{{ action.name }}</span>
+
+          <button
+            @click="startListening(action.bit)"
+            class="text-xs px-3 py-1 rounded bg-purple-500/20 text-purple-300 active:bg-purple-500/30"
+          >
+            Bind
+          </button>
+        </div>
+
+        <!-- Bound keys -->
+        <div class="flex flex-wrap gap-2">
+          <template v-if="getActionBindings(action.bit).length">
+            <div
+              v-for="[code] in getActionBindings(action.bit)"
+              :key="code"
+              class="flex items-center gap-2 px-3 py-1 bg-white/10 rounded-full text-sm"
+            >
+              <span class="font-mono">{{ code }}</span>
+              <button
+                @click="removeBinding(code, action.bit)"
+                class="text-white/40 hover:text-red-400"
+              >
+                ✕
+              </button>
+            </div>
+          </template>
+
+          <span v-else class="text-xs text-white/40"> No bindings </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Reset to defaults -->
+    <div class="mt-10 max-w-xl mx-auto">
+      <button
+        @click="reset"
+        class="w-full flex items-center justify-center gap-2 p-4 bg-red-500/10 border border-red-500/30 text-red-400 font-medium rounded-xl active:bg-red-500/20 transition-all"
+      >
+        Reset to default
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import { useLibraryStore } from "../stores/library";
+import { PicoButton } from "../services/InputManager";
+
+const store = useLibraryStore();
+const headerFocused = ref(false);
+
+const actions = [
+  { name: "Left", bit: PicoButton.LEFT },
+  { name: "Right", bit: PicoButton.RIGHT },
+  { name: "Up", bit: PicoButton.UP },
+  { name: "Down", bit: PicoButton.DOWN },
+
+  { name: "Button O", bit: PicoButton.O },
+  { name: "Button X", bit: PicoButton.X },
+  { name: "Pause", bit: PicoButton.PAUSE },
+];
+
+const listeningFor = ref(null); // bit or null
+let listenTimeout = null;
+let listenInterval = null;
+const listenRemaining = ref(0);
+const LISTEN_DURATION = 3_000; // ms
+const showDialog = ref(false);
+const dialogMessage = ref("");
+const pendingCode = ref("");
+
+const startListening = (bit) => {
+  stopListening();
+
+  listeningFor.value = bit;
+  const start = performance.now();
+  listenRemaining.value = (LISTEN_DURATION / 1000).toFixed(1);
+
+  listenInterval = setInterval(() => {
+    const elapsed = performance.now() - start;
+    const left = Math.max(0, LISTEN_DURATION - elapsed);
+    listenRemaining.value = (left / 1000).toFixed(1);
+  }, 100); // 0.1s resolution
+
+  listenTimeout = setTimeout(() => {
+    stopListening();
+  }, LISTEN_DURATION);
+};
+
+const stopListening = () => {
+  listenRemaining.value = 0;
+
+  if (listenTimeout) {
+    clearTimeout(listenTimeout);
+    listenTimeout = null;
+  }
+
+  if (listenInterval) {
+    clearInterval(listenInterval);
+    listenInterval = null;
+  }
+};
+
+const onKeyDown = (e) => {
+  if (!isListening()) return;
+
+  e.preventDefault();
+  e.stopImmediatePropagation();
+
+  if (!e.isTrusted || e.repeat) return;
+
+  const actions = store.getKeyBindings(e.code);
+
+  if (actions?.length != 0) {
+    pendingCode.value = e.code;
+    dialogMessage.value = `"${e.code}" is already bound to:\n${actions.join(
+      ", "
+    )}\n\nWhat would you like to do?`;
+
+    showDialog.value = true;
+  } else {
+    store.bindKey(e.code, listeningFor.value);
+  }
+
+  stopListening();
+};
+
+onMounted(() => {
+  window.addEventListener("keydown", onKeyDown, true);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onKeyDown, true);
+});
+
+const getActionBindings = (bit) => {
+  return store.getActionBindings(bit);
+};
+
+const removeBinding = (code, bit) => {
+  store.unbindKey(code, bit);
+};
+
+const replaceBinding = () => {
+  store.bindKey(pendingCode.value, listeningFor.value);
+  showDialog.value = false;
+};
+
+const addBinding = () => {
+  store.bindKey(pendingCode.value, listeningFor.value, { append: true });
+  showDialog.value = false;
+};
+
+const isListening = () => {
+  return listenRemaining.value != 0;
+};
+
+const reset = () => {
+  if (
+    confirm(
+      "DANGER: This will reset input bindings to the defaults. Are you sure?"
+    )
+  ) {
+    store.resetKeymap();
+  }
+};
+</script>

--- a/src/views/Input.vue
+++ b/src/views/Input.vue
@@ -136,7 +136,7 @@
         @click="reset"
         class="w-full flex items-center justify-center gap-2 p-4 bg-red-500/10 border border-red-500/30 text-red-400 font-medium rounded-xl active:bg-red-500/20 transition-all"
       >
-        Reset to default
+        Restore defaults
       </button>
     </div>
   </div>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -234,6 +234,13 @@ const settingsItems = computed(() => {
     action: handleRescan,
   });
 
+  items.push({
+    id: "input",
+    label: "Input",
+    subtext: "Change keyboard controls",
+    type: "link",
+    action: goToKeymap,
+  });
   return items;
 });
 
@@ -349,4 +356,8 @@ onMounted(() => {
 onUnmounted(() => {
   if (listenerCleanup.value) listenerCleanup.value();
 });
+
+async function goToKeymap() {
+  router.push({ name: "input" });
+};
 </script>


### PR DESCRIPTION
This PR adds a new 'Input' section to Settings, allowing users to change keyboard controls.

This was implemented to allow to play on phones with built-in QWERTY keyboards, where the default PICO-8 key configuration is impossible to use. But it may also be useful for users connecting external keyboards.

No breaking changes, all defaults are kept the same.

<img width="507" height="381" alt="image" src="https://github.com/user-attachments/assets/0d5eb321-fab1-4934-9def-f314e8f17895" />

<img width="507" height="381" alt="image" src="https://github.com/user-attachments/assets/ee22d8a9-600c-4133-9530-1d4e8ea5aad4" />
